### PR TITLE
workers: 固定 placement 到美区，规避部分 colo 出站被拦导致的 403/500

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -31,3 +31,7 @@ KV_CLEANUP_BATCH = "200"
 [triggers]
 # Every day at 00:00 (Asia/Shanghai => 16:00 UTC)
 crons = ["0 16 * * *"]
+
+[placement]
+# Pin execution near US to avoid upstream blocks seen from some APAC colos (e.g. SIN).
+region = "aws:us-west-2"


### PR DESCRIPTION
背景：部署在 Cloudflare Workers 时，Worker 默认会在访问者就近的 colo 执行。
实测在部分 APAC colo（例如 SIN / 部分 TW 线路）下，Worker 出站请求 grok 上游会触发 Cloudflare Challenge（返回“Just a moment...”），导致 upstream 403，最终接口返回 500（upstream_error）。
而当请求落到 LAX 等美区 colo 时，同样请求可以稳定 200。

改动：在 wrangler.toml 增加 placement hint：

[placement]
region = "aws:us-west-2"

让 Worker 执行/出站更倾向美区，从而规避上述 upstream block（已在实际环境验证生效）。