### PR TITLE
Fix image placeholder URLs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# OpenCode / ace-tool index
+.ace-tool/


### PR DESCRIPTION
## 背景 / 问题
在图像生成场景里，偶发会返回类似 `/images/p_Lw` 的图片链接；`p_Lw` 解码后等价于路径 `/`，客户端拉取必然 404，表现为“黑色小占位图/坏图”。

从 Worker 日志可观察到大量 `GET /images/p_Lw -> 404`，且这些请求并非上游限流，而是本地把空/占位的 `generatedImageUrls` 当成了最终图片 URL 提前结束导致。

## 原因
上游（Grok imagine）是 NDJSON 流式输出，某些中间帧会先出现 `modelResponse.generatedImageUrls`，但其中可能包含空字符串/占位值（如 `""` 或 `"/"`）。
旧逻辑只要看到 `generatedImageUrls` 是数组就直接生成图片链接并结束，导致把占位值编码成 `p_Lw` 返回给客户端。

## 修改
- 过滤/规范化 `generatedImageUrls`：忽略空字符串/纯空白 URL。
- 非流式解析：继续扫描 NDJSON，直到拿到至少 1 个有效 URL 才结束，避免提前返回占位链接。
- 流式解析：同样使用过滤后的 URL 列表生成图片链接。
- 另外：`.gitignore` 增加 `.ace-tool/`，避免本地索引文件误入仓库。

## 影响
- 消除 `/images/p_Lw` 这类坏链接，客户端不再出现黑色占位图。
- 不改变正常情况下的图片返回方式；上游 403/429 等风控/限流问题不在本 PR 解决范围内。
This pull request improves the way generated image URLs are handled and normalized in the `src/grok/processor.ts` file. The changes ensure that only valid, non-empty string URLs are processed, which prevents issues with empty or malformed image links in downstream logic.

**Improvements to image URL handling:**

* Added a new helper function `normalizeGeneratedAssetUrls` to filter and clean up the `generatedImageUrls` array, ensuring only valid, trimmed string URLs are returned.
* Updated both `createOpenAiStreamFromGrokNdjson` and `parseOpenAiFromGrokNdjson` to use `normalizeGeneratedAssetUrls` instead of directly accessing or checking the type of `generatedImageUrls`. This streamlines URL processing and avoids duplicate logic. [[1]](diffhunk://#diff-758f173a7656e0e9ee98cfcc704adde8344983da538ac082029c8b1e4c6f92a0L244-L248) [[2]](diffhunk://#diff-758f173a7656e0e9ee98cfcc704adde8344983da538ac082029c8b1e4c6f92a0L382-R402)
* Enhanced the image generation response handling in `parseOpenAiFromGrokNdjson` to keep scanning for usable URLs, preventing the return of broken image links when only empty or placeholder URLs are present.