### PR TITLE
修复添加 API Key 后被强制退出登录的问题

### DIFF
--- a/app/static/common/admin-auth.js
+++ b/app/static/common/admin-auth.js
@@ -171,7 +171,10 @@ async function requestApiKey(creds) {
   return cachedApiKey;
 }
 
-async function ensureApiKey() {
+async function ensureApiKey(forceRefresh = false) {
+  if (cachedApiKey && !forceRefresh) {
+    return cachedApiKey;
+  }
   const creds = await getStoredAppKey();
   if (!creds || !creds.password) {
     window.location.href = '/login';

--- a/app/static/keys/keys.js
+++ b/app/static/keys/keys.js
@@ -383,14 +383,20 @@ function applyKeyLimitPreset(mode) {
   q('limit-video').value = recommended.video;
 }
 
-async function loadKeys() {
+async function loadKeys(retryOn401 = true) {
   const body = q('keys-table-body');
   if (body) body.innerHTML = '';
   setLoading(true);
   setEmptyState(false);
   try {
     const res = await fetch('/api/v1/admin/keys', { headers: buildAuthHeaders(apiKey) });
-    if (res.status === 401) return logout();
+    if (res.status === 401) {
+      if (retryOn401) {
+        apiKey = await ensureApiKey(true);
+        if (apiKey) return loadKeys(false);
+      }
+      return logout();
+    }
     const payload = await parseJsonSafely(res);
     if (!res.ok || payload?.success !== true) {
       throw new Error(extractErrorMessage(payload, '加载失败'));
@@ -428,7 +434,12 @@ async function submitKeyModal() {
           is_active: isActive,
         }),
       });
-      if (res.status === 401) return logout();
+      if (res.status === 401) {
+        apiKey = await ensureApiKey(true);
+        if (!apiKey) return logout();
+        setSubmitState(false);
+        return submitKeyModal();
+      }
       const payload = await parseJsonSafely(res);
       if (!res.ok || payload?.success !== true) {
         throw new Error(extractErrorMessage(payload, '创建失败'));
@@ -457,7 +468,12 @@ async function submitKeyModal() {
         limits,
       }),
     });
-    if (res.status === 401) return logout();
+    if (res.status === 401) {
+      apiKey = await ensureApiKey(true);
+      if (!apiKey) return logout();
+      setSubmitState(false);
+      return submitKeyModal();
+    }
     const payload = await parseJsonSafely(res);
     if (!res.ok || payload?.success !== true) {
       throw new Error(extractErrorMessage(payload, '更新失败'));
@@ -484,7 +500,11 @@ async function deleteKey(row) {
       headers: { ...buildAuthHeaders(apiKey), 'Content-Type': 'application/json' },
       body: JSON.stringify({ key }),
     });
-    if (res.status === 401) return logout();
+    if (res.status === 401) {
+      apiKey = await ensureApiKey(true);
+      if (!apiKey) return logout();
+      return deleteKey(row);
+    }
     const payload = await parseJsonSafely(res);
     if (!res.ok || payload?.success !== true) {
       throw new Error(extractErrorMessage(payload, '删除失败'));


### PR DESCRIPTION
## 问题
Issue #38

添加 API Key 后，管理后台会自动退出登录，无法保持登录状态。

## 原因

每次 API 操作都会重新请求登录接口获取 token，遇到 401 错误时直接清除登录状态并跳转到登录页。

## 修复

1. 在 `ensureApiKey()` 中添加缓存机制，避免重复请求
2. 遇到 401 时先刷新 token 重试一次，而不是直接退出
3. 只有刷新失败才真正执行 logout

## 测试

- 添加 API Key 不再退出登录
- 编辑/删除 API Key 保持登录状态
- 真正的认证失败仍会正常退出